### PR TITLE
Resolves race condition in layer reuse integration tests

### DIFF
--- a/integration/buildpack_yaml_test.go
+++ b/integration/buildpack_yaml_test.go
@@ -42,6 +42,9 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "buildpack_yaml_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -52,11 +55,11 @@ func testBuildpackYAML(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("builds with the settings in buildpack.yml", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "buildpack_yaml_app"))
-			Expect(err).NotTo(HaveOccurred())
+			var (
+				logs fmt.Stringer
+				err  error
+			)
 
-			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
 				WithBuildpacks(buildpack, buildPlanBuildpack).

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -42,6 +42,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		it.After(func() {
@@ -52,11 +56,11 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("builds with the defaults", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
+			var (
+				logs fmt.Stringer
+				err  error
+			)
 
-			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
 				WithBuildpacks(buildpack, buildPlanBuildpack).

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -42,6 +42,9 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -52,11 +55,11 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("installs golang", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
+			var (
+				logs fmt.Stringer
+				err  error
+			)
 
-			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
 				WithNoPull().
 				WithBuildpacks(offlineBuildpack, buildPlanBuildpack).


### PR DESCRIPTION
Looks like they were getting the same source and image name and so creating a race between parallel tests.