### PR TITLE
Use scribe.emitter generic logger for EOS logging

### DIFF
--- a/log_emitter.go
+++ b/log_emitter.go
@@ -3,20 +3,18 @@ package godist
 import (
 	"io"
 	"strconv"
-	"time"
 
 	"github.com/paketo-buildpacks/packit"
-	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/paketo-buildpacks/packit/scribe"
 )
 
 type LogEmitter struct {
-	scribe.Logger
+	scribe.Emitter
 }
 
 func NewLogEmitter(output io.Writer) LogEmitter {
 	return LogEmitter{
-		Logger: scribe.NewLogger(output),
+		Emitter: scribe.NewEmitter(output),
 	}
 }
 
@@ -52,29 +50,6 @@ func (l LogEmitter) Candidates(entries []packit.BuildpackPlanEntry) {
 
 	for _, source := range sources {
 		l.Action(("%-" + strconv.Itoa(maxLen) + "s -> %q"), source[0], source[1])
-	}
-
-	l.Break()
-}
-
-func (l LogEmitter) SelectedDependency(entry packit.BuildpackPlanEntry, dependency postal.Dependency, now time.Time) {
-	versionSource, ok := entry.Metadata["version-source"]
-	if !ok {
-		versionSource = "<unknown>"
-	}
-
-	l.Subprocess("Selected %s version (using %s): %s", dependency.Name, versionSource, dependency.Version)
-
-	if (dependency.DeprecationDate != time.Time{}) {
-		deprecationDate := dependency.DeprecationDate
-		switch {
-		case (deprecationDate.Add(-30*24*time.Hour).Before(now) && deprecationDate.After(now)):
-			l.Action("Version %s of %s will be deprecated after %s.", dependency.Version, dependency.Name, dependency.DeprecationDate.Format("2006-01-02"))
-			l.Action("Migrate your application to a supported version of %s before this time.", dependency.Name)
-		case (deprecationDate == now || deprecationDate.Before(now)):
-			l.Action("Version %s of %s is deprecated.", dependency.Version, dependency.Name)
-			l.Action("Migrate your application to a supported version of %s.", dependency.Name)
-		}
 	}
 
 	l.Break()

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -3,11 +3,9 @@ package godist_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	godist "github.com/paketo-buildpacks/go-dist"
 	"github.com/paketo-buildpacks/packit"
-	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -56,65 +54,6 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
       <unknown>   -> "other-version"
 
 `))
-		})
-	})
-
-	context("SelectedDependency", func() {
-		var (
-			entry      packit.BuildpackPlanEntry
-			dependency postal.Dependency
-		)
-
-		it.Before(func() {
-			entry = packit.BuildpackPlanEntry{
-				Metadata: map[string]interface{}{
-					"version-source": "some-source",
-				},
-			}
-
-			dependency = postal.Dependency{
-				Name:    "Go",
-				Version: "some-version",
-			}
-
-			var err error
-			dependency.DeprecationDate, err = time.Parse(time.RFC3339, "2021-04-01T00:00:00Z")
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		it("logs the selected dependency", func() {
-			emitter.SelectedDependency(entry, dependency, time.Now())
-			Expect(buffer.String()).To(Equal("    Selected Go version (using some-source): some-version\n\n"))
-		})
-
-		context("when it is within 30 days of the deprecation date", func() {
-			var now time.Time
-
-			it.Before(func() {
-				now = dependency.DeprecationDate.Add(-29 * 24 * time.Hour)
-			})
-
-			it("returns a warning that the dependency will be deprecated after the deprecation date", func() {
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Go version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Go will be deprecated after 2021-04-01.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Go before this time.\n\n"))
-			})
-		})
-
-		context("when it is on the the deprecation date", func() {
-			var now time.Time
-
-			it.Before(func() {
-				now = dependency.DeprecationDate
-			})
-
-			it("returns a warning that the version of the dependency is no longer supported", func() {
-				emitter.SelectedDependency(entry, dependency, now)
-				Expect(buffer.String()).To(ContainSubstring("    Selected Go version (using some-source): some-version\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Version some-version of Go is deprecated.\n"))
-				Expect(buffer.String()).To(ContainSubstring("      Migrate your application to a supported version of Go.\n\n"))
-			})
 		})
 	})
 }


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

Use scribe.emitter generic logger for EOS logging

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
