### PR TITLE
Adds support for BP_GO_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,26 @@ $ ./scripts/package.sh
 This builds the buildpack's Go source using `GOOS=linux` by default. You can
 supply another value as the first argument to `package.sh`.
 
-## `buildpack.yml` Configurations
+## Go Build Configuration
 
+Specifying the `Go Dist` configuration through `buildpack.yml` configuration
+will be deprecated in Go Build Buildpack v1.0.0.
+
+To migrate from using `buildpack.yml` please set the following environment
+variables at build time either directly (ex. `pack build my-app --env
+BP_ENVIRONMENT_VARIABLE=some-value`) or through a [`project.toml`
+file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
+
+### `BP_GO_VERSION`
+The `BP_GO_VERSION` variable allows you to specify the version of Go that is
+installed.
+
+```shell
+BP_GO_VERSION=1.14.1
+```
+
+This will replace the following structure in `buildpack.yml`:
 ```yaml
 go:
-  # this allows you to specify a version constaint for the Go dependency
-  # any valid semver constaints (e.g. 1.* and 1.14.*) are also acceptable
   version: 1.14.1
 ```

--- a/build.go
+++ b/build.go
@@ -45,6 +45,13 @@ func Build(entries EntryResolver, dependencies DependencyManager, planRefinery P
 		logs.SelectedDependency(entry, dependency, clock.Now())
 		bom := planRefinery.BillOfMaterials(dependency)
 
+		source, _ := entry.Metadata["version-source"].(string)
+		if source == "buildpack.yml" {
+			logs.Subprocess("WARNING: Setting the Go Dist version through buildpack.yml will be deprecated soon in Go Dist Buildpack v1.0.0.")
+			logs.Subprocess("Please specify the version through the $BP_GO_VERSION environment variable instead. See README.md for more information.")
+			logs.Break()
+		}
+
 		goLayer, err := context.Layers.Get(GoLayerName)
 		if err != nil {
 			return packit.BuildResult{}, err

--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,7 @@
 package godist
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit"
@@ -20,6 +21,17 @@ type BuildPlanMetadata struct {
 func Detect(buildpackYAMLParser VersionParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
 		var requirements []packit.BuildPlanRequirement
+
+		if version, ok := os.LookupEnv("BP_GO_VERSION"); ok {
+			requirements = append(requirements, packit.BuildPlanRequirement{
+				Name: GoDependency,
+				Metadata: BuildPlanMetadata{
+					VersionSource: "BP_GO_VERSION",
+					Version:       version,
+				},
+			})
+		}
+
 		version, err := buildpackYAMLParser.ParseVersion(filepath.Join(context.WorkingDir, "buildpack.yml"))
 		if err != nil {
 			return packit.DetectResult{}, err

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -75,6 +75,7 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("BuildpackYAML", testBuildpackYAML)
 	suite("Default", testDefault)
+	suite("EnvironmentVariableConfiguration", testEnvironmentVariableConfiguration)
 	suite("LayerReuse", testLayerReuse)
 	suite("Offline", testOffline)
 	suite.Run(t)

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -163,7 +163,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
 
-			source, err = occam.Source(filepath.Join("testdata", "buildpack_yaml_app"))
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -176,6 +176,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			firstImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
+				WithEnv(map[string]string{"BP_GO_VERSION": "1.14.*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -197,16 +198,11 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(firstContainer).Should(BeAvailable())
 
-			err = ioutil.WriteFile(filepath.Join(source, "buildpack.yml"), []byte(`---
-go:
-  version: 1.14.*
-`), 0644)
-			Expect(err).NotTo(HaveOccurred())
-
 			// Second pack build
 			secondImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
+				WithEnv(map[string]string{"BP_GO_VERSION": "1.15.*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -230,7 +230,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			content, err := ioutil.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(content).To(ContainSubstring("go1.14"))
+			Expect(content).To(ContainSubstring("go1.15"))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].Metadata["built_at"]).NotTo(Equal(firstImage.Buildpacks[0].Layers["go"].Metadata["built_at"]))
 		})

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -18,6 +18,7 @@ func NewPlanEntryResolver(logger LogEmitter) PlanEntryResolver {
 
 func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.BuildpackPlanEntry {
 	priorities := map[string]int{
+		"BP_GO_VERSION": 3,
 		"buildpack.yml": 2,
 		"go.mod":        1,
 		"":              -1,

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -24,6 +24,53 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		resolver = godist.NewPlanEntryResolver(godist.NewLogEmitter(buffer))
 	})
 
+	context("when a BP_GO_VERSION entry is included", func() {
+		it("resolves the best plan entry", func() {
+			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
+				{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"version":        "go-mod-version",
+						"version-source": "go.mod",
+					},
+				},
+				{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
+				},
+				{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"version":        "BP_GO_VERSION-version",
+						"version-source": "BP_GO_VERSION",
+					},
+				},
+				{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"version":        "buildpack-yml-version",
+						"version-source": "buildpack.yml",
+					},
+				},
+			})
+			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
+				Name: "go",
+				Metadata: map[string]interface{}{
+					"version":        "BP_GO_VERSION-version",
+					"version-source": "BP_GO_VERSION",
+				},
+			}))
+
+			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
+			Expect(buffer.String()).To(ContainSubstring("      BP_GO_VERSION -> \"BP_GO_VERSION-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      go.mod        -> \"go-mod-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
+		})
+	})
+
 	context("when a buildpack.yml entry is included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{


### PR DESCRIPTION
- Adds support to specify Go version with environment variable as laid
out in [RFC 0001](https://github.com/paketo-buildpacks/go-dist/blob/main/rfcs/0001-buildpack-yml-to-env-var.md).
This commit also implements that warning system that is laid out in the
aforementioned RFC.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
