### PR TITLE
Bumps default version to 1.16

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,7 +9,7 @@ api = "0.5"
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml", "go.mod", "go.sum"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    go = "1.15.*"
+    go = "1.16.*"
 
   [[metadata.dependencies]]
     deprecation_date = "2021-02-25T00:00:00Z"

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -73,7 +73,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
@@ -81,10 +81,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.15\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.16\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.15\.\d+`),
+				MatchRegexp(`    Installing Go 1\.16\.\d+`),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 			))
 		})

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -83,10 +83,10 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.15\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.16\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.15\.\d+`),
+				MatchRegexp(`    Installing Go 1\.16\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 			))
 
@@ -121,7 +121,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.15\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.16\.\d+`),
 				"",
 				fmt.Sprintf("  Reusing cached layer /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
@@ -136,7 +136,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].Metadata["built_at"]).To(Equal(firstImage.Buildpacks[0].Layers["go"].Metadata["built_at"]))
 		})

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -74,7 +74,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This updates the default version of Go to be installed by the buildpack to 1.16.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
