### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/go-dist"
   id = "paketo-buildpacks/go-dist"
   keywords = ["go", "distribution", "compiler"]
-  name = "Paketo Go Distribution Buildpack"
+  name = "Paketo Buildpack for Go Distribution"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Go Distribution Buildpack' to 'Paketo Buildpack for Go Distribution'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
