### PR TITLE
Remove Go 1.18. makes Go 1.19 the default

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,35 +16,7 @@ api = "0.7"
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    go = "1.18.*"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:015692d2a48e3496f1da3328cf33337c727c595011883f6fc74f9b5a9c86ffa8"
-    cpe = "cpe:2.3:a:golang:go:1.18.9:*:*:*:*:*:*:*"
-    id = "go"
-    licenses = ["BSD-3-Clause"]
-    name = "Go"
-    purl = "pkg:generic/go@go1.18.9?checksum=015692d2a48e3496f1da3328cf33337c727c595011883f6fc74f9b5a9c86ffa8&download_url=https://go.dev/dl/go1.18.9.linux-amd64.tar.gz"
-    source = "https://go.dev/dl/go1.18.9.src.tar.gz"
-    source-checksum = "sha256:fbe7f09b96aca3db6faeaf180da8bb632868ec049731e355ff61695197c0e3ea"
-    stacks = ["*"]
-    strip-components = 1
-    uri = "https://go.dev/dl/go1.18.9.linux-amd64.tar.gz"
-    version = "1.18.9"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49"
-    cpe = "cpe:2.3:a:golang:go:1.18.10:*:*:*:*:*:*:*"
-    id = "go"
-    licenses = ["BSD-3-Clause"]
-    name = "Go"
-    purl = "pkg:generic/go@go1.18.10?checksum=5e05400e4c79ef5394424c0eff5b9141cb782da25f64f79d54c98af0a37f8d49&download_url=https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
-    source = "https://go.dev/dl/go1.18.10.src.tar.gz"
-    source-checksum = "sha256:9cedcca58845df0c9474ae00274c44a95c9dfaefb132fc59921c28c7c106f8e6"
-    stacks = ["*"]
-    strip-components = 1
-    uri = "https://go.dev/dl/go1.18.10.linux-amd64.tar.gz"
-    version = "1.18.10"
+    go = "1.19.*"
 
   [[metadata.dependencies]]
     checksum = "sha256:e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d"
@@ -101,11 +73,6 @@ api = "0.7"
     strip-components = 1
     uri = "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz"
     version = "1.20.2"
-
-  [[metadata.dependency-constraints]]
-    constraint = "1.18.*"
-    id = "go"
-    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "1.19.*"

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -85,7 +85,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.18")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
@@ -93,10 +93,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.18\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.18\.\d+`),
+				MatchRegexp(`    Installing Go 1\.19\.\d+`),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
 				fmt.Sprintf("  Generating SBOM for /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),

--- a/integration/environment_variable_configuration_test.go
+++ b/integration/environment_variable_configuration_test.go
@@ -65,7 +65,7 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(buildpack, buildPlanBuildpack).
-					WithEnv(map[string]string{"BP_GO_VERSION": "1.19.*"}).
+					WithEnv(map[string]string{"BP_GO_VERSION": "1.20.*"}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -77,19 +77,19 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
+				Eventually(container).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
 
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 					"  Resolving Go version",
 					"    Candidate version sources (in priority order):",
-					"      BP_GO_VERSION -> \"1.19.*\"",
+					"      BP_GO_VERSION -> \"1.20.*\"",
 					"      <unknown>     -> \"\"",
 					"",
-					MatchRegexp(`    Selected Go version \(using BP_GO_VERSION\): 1\.19\.\d+`),
+					MatchRegexp(`    Selected Go version \(using BP_GO_VERSION\): 1\.20\.\d+`),
 					"",
 					"  Executing build process",
-					MatchRegexp(`    Installing Go 1\.19\.\d+`),
+					MatchRegexp(`    Installing Go 1\.20\.\d+`),
 					MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				))
 			})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -71,7 +71,7 @@ func TestIntegration(t *testing.T) {
 		Execute(config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyTimeout(60 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -71,7 +71,7 @@ func TestIntegration(t *testing.T) {
 		Execute(config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(15 * time.Second)
+	SetDefaultEventuallyTimeout(30 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -71,7 +71,7 @@ func TestIntegration(t *testing.T) {
 		Execute(config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyTimeout(15 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -83,10 +83,10 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.18\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.18\.\d+`),
+				MatchRegexp(`    Installing Go 1\.19\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
 			))
 
@@ -121,7 +121,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.18\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
 				"",
 				fmt.Sprintf("  Reusing cached layer /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
@@ -136,7 +136,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.18")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})
@@ -192,7 +192,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			secondImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
-				WithEnv(map[string]string{"BP_GO_VERSION": "1.18.*"}).
+				WithEnv(map[string]string{"BP_GO_VERSION": "1.20.*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -212,7 +212,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.18")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -74,7 +74,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.18")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
 		})
 	})
 }


### PR DESCRIPTION
Resolves #538 