### PR TITLE
Add Go 1.21, drop 1.19, update default to 1.20

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,35 +16,7 @@ api = "0.7"
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    go = "1.19.*"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:ee18f98a03386e2bf48ff75737ea17c953b1572f9b1114352f104ac5eef04bb4"
-    cpe = "cpe:2.3:a:golang:go:1.19.11:*:*:*:*:*:*:*"
-    id = "go"
-    licenses = ["BSD-3-Clause"]
-    name = "Go"
-    purl = "pkg:generic/go@go1.19.11?checksum=ee18f98a03386e2bf48ff75737ea17c953b1572f9b1114352f104ac5eef04bb4&download_url=https://go.dev/dl/go1.19.11.linux-amd64.tar.gz"
-    source = "https://go.dev/dl/go1.19.11.src.tar.gz"
-    source-checksum = "sha256:e25c9ab72d811142b7f41ff6da5165fec2d1be5feec3ef2c66bc0bdecb431489"
-    stacks = ["*"]
-    strip-components = 1
-    uri = "https://go.dev/dl/go1.19.11.linux-amd64.tar.gz"
-    version = "1.19.11"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:48e4fcfb6abfdaa01aaf1429e43bdd49cea5e4687bd5f5b96df1e193fcfd3e7e"
-    cpe = "cpe:2.3:a:golang:go:1.19.12:*:*:*:*:*:*:*"
-    id = "go"
-    licenses = ["BSD-3-Clause"]
-    name = "Go"
-    purl = "pkg:generic/go@go1.19.12?checksum=48e4fcfb6abfdaa01aaf1429e43bdd49cea5e4687bd5f5b96df1e193fcfd3e7e&download_url=https://go.dev/dl/go1.19.12.linux-amd64.tar.gz"
-    source = "https://go.dev/dl/go1.19.12.src.tar.gz"
-    source-checksum = "sha256:ee5d50e0a7fd74ba1b137cb879609aaaef9880bf72b5d1742100e38ae72bb557"
-    stacks = ["*"]
-    strip-components = 1
-    uri = "https://go.dev/dl/go1.19.12.linux-amd64.tar.gz"
-    version = "1.19.12"
+    go = "1.20.*"
 
   [[metadata.dependencies]]
     checksum = "sha256:b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1eb"
@@ -74,13 +46,27 @@ api = "0.7"
     uri = "https://go.dev/dl/go1.20.7.linux-amd64.tar.gz"
     version = "1.20.7"
 
+  [[metadata.dependencies]]
+    checksum = "sha256:d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742"
+    cpe = "cpe:2.3:a:golang:go:1.21.0:*:*:*:*:*:*:*"
+    id = "go"
+    licenses = ["BSD-3-Clause"]
+    name = "Go"
+    purl = "pkg:generic/go@go1.21.0?checksum=d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742&download_url=https://go.dev/dl/go1.21.0.linux-amd64.tar.gz"
+    source = "https://go.dev/dl/go1.21.0.src.tar.gz"
+    source-checksum = "sha256:818d46ede85682dd551ad378ef37a4d247006f12ec59b5b755601d2ce114369a"
+    stacks = ["*"]
+    strip-components = 1
+    uri = "https://go.dev/dl/go1.21.0.linux-amd64.tar.gz"
+    version = "1.21.0"
+
   [[metadata.dependency-constraints]]
-    constraint = "1.19.*"
+    constraint = "1.20.*"
     id = "go"
     patches = 2
 
   [[metadata.dependency-constraints]]
-    constraint = "1.20.*"
+    constraint = "1.21.*"
     id = "go"
     patches = 2
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -85,7 +85,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
@@ -93,10 +93,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.20\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.19\.\d+`),
+				MatchRegexp(`    Installing Go 1\.20\.\d+`),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
 				fmt.Sprintf("  Generating SBOM for /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),

--- a/integration/environment_variable_configuration_test.go
+++ b/integration/environment_variable_configuration_test.go
@@ -65,7 +65,7 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(buildpack, buildPlanBuildpack).
-					WithEnv(map[string]string{"BP_GO_VERSION": "1.20.*"}).
+					WithEnv(map[string]string{"BP_GO_VERSION": "1.21.*"}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -77,19 +77,19 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
+				Eventually(container).Should(Serve(ContainSubstring("go1.21")).OnPort(8080))
 
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 					"  Resolving Go version",
 					"    Candidate version sources (in priority order):",
-					"      BP_GO_VERSION -> \"1.20.*\"",
+					"      BP_GO_VERSION -> \"1.21.*\"",
 					"      <unknown>     -> \"\"",
 					"",
-					MatchRegexp(`    Selected Go version \(using BP_GO_VERSION\): 1\.20\.\d+`),
+					MatchRegexp(`    Selected Go version \(using BP_GO_VERSION\): 1\.21\.\d+`),
 					"",
 					"  Executing build process",
-					MatchRegexp(`    Installing Go 1\.20\.\d+`),
+					MatchRegexp(`    Installing Go 1\.21\.\d+`),
 					MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				))
 			})

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -83,10 +83,10 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.20\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.19\.\d+`),
+				MatchRegexp(`    Installing Go 1\.20\.\d+`),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
 			))
 
@@ -121,7 +121,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.19\.\d+`),
+				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.20\.\d+`),
 				"",
 				fmt.Sprintf("  Reusing cached layer /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
@@ -136,7 +136,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})
@@ -166,7 +166,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			firstImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
-				WithEnv(map[string]string{"BP_GO_VERSION": "1.19.*"}).
+				WithEnv(map[string]string{"BP_GO_VERSION": "1.20.*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -192,7 +192,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			secondImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
-				WithEnv(map[string]string{"BP_GO_VERSION": "1.20.*"}).
+				WithEnv(map[string]string{"BP_GO_VERSION": "1.21.*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -212,7 +212,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.21")).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -74,7 +74,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.19")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.20")).OnPort(8080))
 		})
 	})
 }


### PR DESCRIPTION
## Summary
I wanted support for Go 1.21, so I looked up recent change patterns and did the following:

- Added support for Go 1.21
- Dropped support for Go 1.19 which will no longer be updated
- Updated default Go version from 1.19 to 1.20

## Use Cases

This will enable Go buildpack users to build with Go 1.21.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
