### PR TITLE
Drop go 1.23 add go 1.25

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.7"
   include-files = ["buildpack.toml", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/run", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/run"]
   pre-package = "./scripts/build.sh --target linux/amd64 --target linux/arm64"
   [metadata.default-versions]
-    go = "1.23.*"
+    go = "1.24.*"
 
   [[metadata.dependencies]]
     arch = "amd64"
@@ -147,12 +147,12 @@ api = "0.7"
     version = "1.24.7"
 
   [[metadata.dependency-constraints]]
-    constraint = "1.23.*"
+    constraint = "1.24.*"
     id = "go"
     patches = 2
 
   [[metadata.dependency-constraints]]
-    constraint = "1.24.*"
+    constraint = "1.25.*"
     id = "go"
     patches = 2
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -85,7 +85,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.23")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go" + defaultVersion)).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
@@ -93,10 +93,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.23\.\d+`),
+				MatchRegexp(fmt.Sprintf(`    Selected Go version \(using <unknown>\): %s\.\d+`, defaultVersion)),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.23\.\d+`),
+				MatchRegexp(fmt.Sprintf(`    Installing Go %s\.\d+`, defaultVersion)),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
 				fmt.Sprintf("  Generating SBOM for /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),

--- a/integration/environment_variable_configuration_test.go
+++ b/integration/environment_variable_configuration_test.go
@@ -65,7 +65,7 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").
 					WithBuildpacks(buildpack, buildPlanBuildpack).
-					WithEnv(map[string]string{"BP_GO_VERSION": "1.23.*"}).
+					WithEnv(map[string]string{"BP_GO_VERSION": defaultVersion + ".*"}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -77,19 +77,19 @@ func testEnvironmentVariableConfiguration(t *testing.T, context spec.G, it spec.
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(Serve(ContainSubstring("go1.23")).OnPort(8080))
+				Eventually(container).Should(Serve(ContainSubstring("go" + defaultVersion)).OnPort(8080))
 
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 					"  Resolving Go version",
 					"    Candidate version sources (in priority order):",
-					"      BP_GO_VERSION -> \"1.23.*\"",
+					fmt.Sprintf("      BP_GO_VERSION -> \"%s.*\"", defaultVersion),
 					"      <unknown>     -> \"\"",
 					"",
-					MatchRegexp(`    Selected Go version \(using BP_GO_VERSION\): 1\.23\.\d+`),
+					MatchRegexp(fmt.Sprintf(`    Selected Go version \(using BP_GO_VERSION\): %s\.\d+`, defaultVersion)),
 					"",
 					"  Executing build process",
-					MatchRegexp(`    Installing Go 1\.23\.\d+`),
+					MatchRegexp(fmt.Sprintf(`    Installing Go %s\.\d+`, defaultVersion)),
 					MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				))
 			})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/onsi/gomega/format"
 	"github.com/paketo-buildpacks/occam"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -21,6 +23,7 @@ var (
 	buildPlanBuildpack string
 	offlineBuildpack   string
 	root               string
+	defaultVersion     string
 
 	buildpackInfo struct {
 		Buildpack struct {
@@ -52,6 +55,14 @@ func TestIntegration(t *testing.T) {
 
 	_, err = toml.NewDecoder(file).Decode(&buildpackInfo)
 	Expect(err).NotTo(HaveOccurred())
+
+	parser := cargo.NewBuildpackParser()
+	buildpackTomlConfig, err := parser.Parse("../buildpack.toml")
+	Expect(err).NotTo(HaveOccurred())
+
+	goDefaultVersion, ok := buildpackTomlConfig.Metadata.DefaultVersions["go"]
+	defaultVersion = strings.TrimRight(goDefaultVersion, ".*")
+	Expect(ok).To(BeTrue())
 
 	root, err = filepath.Abs("./..")
 	Expect(err).ToNot(HaveOccurred())

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -83,10 +83,10 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.23\.\d+`),
+				MatchRegexp(fmt.Sprintf(`    Selected Go version \(using <unknown>\): %s\.\d+`, defaultVersion)),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Go 1\.23\.\d+`),
+				MatchRegexp(fmt.Sprintf(`    Installing Go %s\.\d+`, defaultVersion)),
 				MatchRegexp(`      Completed in \d+(\.?\d+)*`),
 			))
 
@@ -121,7 +121,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				"    Candidate version sources (in priority order):",
 				"      <unknown> -> \"\"",
 				"",
-				MatchRegexp(`    Selected Go version \(using <unknown>\): 1\.23\.\d+`),
+				MatchRegexp(fmt.Sprintf(`    Selected Go version \(using <unknown>\): %s\.\d+`, defaultVersion)),
 				"",
 				fmt.Sprintf("  Reusing cached layer /layers/%s/go", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 			))
@@ -136,7 +136,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.23")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go" + defaultVersion)).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})
@@ -166,7 +166,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			firstImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
-				WithEnv(map[string]string{"BP_GO_VERSION": "1.23.*"}).
+				WithEnv(map[string]string{"BP_GO_VERSION": defaultVersion + ".*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -192,7 +192,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 			secondImage, _, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(buildpack, buildPlanBuildpack).
-				WithEnv(map[string]string{"BP_GO_VERSION": "1.24.*"}).
+				WithEnv(map[string]string{"BP_GO_VERSION": defaultVersion + ".*"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -212,7 +212,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			containerIDs[secondContainer.ID] = struct{}{}
 
-			Eventually(secondContainer).Should(Serve(ContainSubstring("go1.24")).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(ContainSubstring("go" + defaultVersion)).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["go"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["go"].SHA))
 		})

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -74,7 +74,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.23")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go" + defaultVersion)).OnPort(8080))
 		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change updates buildpack.toml so the default go version used going forward will be 1.24. It adds a new 1.25 version constraint and removes the 1.23 version constraint so 1.23.x versions are removed by the Update Metadata Dependencies workflow. 

This change also updates the integration tests to use the default version determined from buildpack.toml rather than hard-coded versions which require manual updates when go the default version reaches end-of-life.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Go 1.23 has reached end of life.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
